### PR TITLE
Fix sort of prices for `priceIs...` functions

### DIFF
--- a/drivers/generic_dap_device.js
+++ b/drivers/generic_dap_device.js
@@ -410,7 +410,7 @@ class MyDevice extends Homey.Device {
 	async priceIsLowestToday(args) {
 		if (!this.state || !this.state.pricesThisDay) throw Error('no prices available');
 		// sort and select number of lowest prices
-		const lowestNPrices = [...this.state.pricesThisDay].sort().slice(0, args.number);
+		const lowestNPrices = [...this.state.pricesThisDay].sort((a, b) => a - b).slice(0, args.number);
 		return this.state.priceNow <= Math.max(...lowestNPrices);
 	}
 
@@ -434,7 +434,7 @@ class MyDevice extends Homey.Device {
 		const pricesPartToday = this.state.pricesThisDay.slice(startHour, endHour);
 		const pricesTotalPeriod = [...pricesPartYesterday, ...pricesPartToday, ...pricesPartTomorrow];
 		// sort and select number of lowest prices
-		const lowestNPrices = pricesTotalPeriod.sort().slice(0, args.number);
+		const lowestNPrices = pricesTotalPeriod.sort((a, b) => a - b).slice(0, args.number);
 		return this.state.priceNow <= Math.max(...lowestNPrices);
 	}
 
@@ -444,7 +444,7 @@ class MyDevice extends Homey.Device {
 		const period = args.period ? args.period : 99;
 		const comingXhours = [...this.state.pricesNextHours].slice(0, period);
 		// sort and select number of lowest prices
-		const lowestNPrices = comingXhours.sort().slice(0, args.number);
+		const lowestNPrices = comingXhours.sort((a, b) => a - b).slice(0, args.number);
 		return this.state.priceNow <= Math.max(...lowestNPrices);
 	}
 
@@ -486,7 +486,7 @@ class MyDevice extends Homey.Device {
 	async priceIsHighestToday(args) {
 		if (!this.state || !this.state.pricesThisDay) throw Error('no prices available');
 		// sort and select number of highest prices
-		const highestNPrices = [...this.state.pricesThisDay].sort().reverse().slice(0, args.number);
+		const highestNPrices = [...this.state.pricesThisDay].sort((a, b) => a - b).reverse().slice(0, args.number);
 		return this.state.priceNow >= Math.min(...highestNPrices);
 	}
 
@@ -495,7 +495,7 @@ class MyDevice extends Homey.Device {
 		// select number of coming hours
 		const comingXhours = [...this.state.pricesNextHours].slice(0, args.period);
 		// sort and select number of highest prices
-		const highestNPrices = comingXhours.sort().reverse().slice(0, args.number);
+		const highestNPrices = comingXhours.sort((a, b) => a - b).reverse().slice(0, args.number);
 		return this.state.priceNow >= Math.min(...highestNPrices);
 	}
 
@@ -519,7 +519,7 @@ class MyDevice extends Homey.Device {
 		const pricesPartToday = this.state.pricesThisDay.slice(startHour, endHour);
 		const pricesTotalPeriod = [...pricesPartYesterday, ...pricesPartToday, ...pricesPartTomorrow];
 		// sort and select number of lowest prices
-		const highestNPrices = pricesTotalPeriod.sort().reverse().slice(0, args.number);
+		const highestNPrices = pricesTotalPeriod.sort((a, b) => a - b).reverse().slice(0, args.number);
 		return this.state.priceNow >= Math.min(...highestNPrices);
 	}
 


### PR DESCRIPTION
The current way `sort` is used only works for numbers `< 1` and also not for all negative ranges, since I have my prices converted to cents I was wondering why the When-triggers were not correctly firing for "The price becomes one of **`number`** lowest in the **`period`** hours before **`time`** o'clock" etc.

You can simply see this by this example:

```
let test1 = [1, 3, 2, 15, -13, -12, 4];
let test2 = [0.1, 0.3, 0.2, 0.15, -0.13, -0.12, 4 ];

console.log(test1.sort()); // [-12, -13, 1, 15, 2, 3, 4]
console.log(test2.sort()); // [-0.12, -0.13, 0.1, 0.15, 0.2, 0.3, ...]

console.log(test1.sort((a, b) => a - b)); // [-13, -12, 1, 2, 3, 4, 15]
console.log(test2.sort((a, b) => a - b)); // [-0.13, -0.12, 0.1, 0.15, 0.2, 0.3, ...]
```

I've changed all occurences in `generc_dap_device.js` (which seems to be the only file using `sort`) to use the correct sort function.