### PR TITLE
Reduce impact of image limits by caching it on homey

### DIFF
--- a/drivers/generic_bat_device.js
+++ b/drivers/generic_bat_device.js
@@ -25,6 +25,7 @@ const util = require('util');
 const charts = require('../charts');
 const tradeStrategy = require('../hedge_strategy'); // deprecated
 const roiStrategy = require('../hedge_roi_glpk'); // new method
+const { imageUrlToStream } = require('../image');
 
 const setTimeoutPromise = util.promisify(setTimeout);
 
@@ -519,11 +520,11 @@ class batDevice extends Device {
       const urlNextHours = await charts.getChargeChart(strategy, H0, this.pricesNextHoursMarketLength, this.getSettings().chargePower, this.getSettings().dischargePower);
       if (!this.nextHoursChargeImage) {
         this.nextHoursChargeImage = await this.homey.images.createImage();
-        await this.nextHoursChargeImage.setUrl(urlNextHours);
         await this.setCameraImage('nextHoursChargeChart', ` ${this.homey.__('nextHours')}`, this.nextHoursChargeImage);
-      } else {
-        await this.nextHoursChargeImage.setUrl(urlNextHours);
       }
+      this.nextHoursChargeImage.setStream(async (stream) => {
+        return imageUrlToStream(urlNextHours, stream);
+      });
       await this.nextHoursChargeImage.update().catch(this.error);
     }
     return Promise.resolve(true);

--- a/drivers/generic_dap_device.js
+++ b/drivers/generic_dap_device.js
@@ -24,6 +24,7 @@ const util = require('util');
 const ECB = require('../ecb_exchange_rates');
 const FORECAST = require('../stekker');
 const charts = require('../charts');
+const { imageUrlToStream } = require('../image');
 
 const setTimeoutPromise = util.promisify(setTimeout);
 
@@ -943,33 +944,33 @@ class MyDevice extends Homey.Device {
     const urlToday = await charts.getPriceChart(this.state.pricesThisDay, 0, 999, this.priceInterval);
     if (!this.todayPriceImage) {
       this.todayPriceImage = await this.homey.images.createImage();
-      await this.todayPriceImage.setUrl(urlToday);
       await this.setCameraImage('todayPriceChart', ` ${this.homey.__('today')}`, this.todayPriceImage);
-    } else {
-      await this.todayPriceImage.setUrl(urlToday);
-      await this.todayPriceImage.update();
     }
+    this.todayPriceImage.setStream(async (stream) => {
+      return imageUrlToStream(urlToday, stream);
+    });
+    await this.todayPriceImage.update();
 
     const urlTomorow = await charts.getPriceChart(this.state.pricesTomorrow, 0, this.state.pricesTomorrowMarketLength, this.priceInterval);
     if (!this.tomorrowPriceImage) {
       this.tomorrowPriceImage = await this.homey.images.createImage();
-      await this.tomorrowPriceImage.setUrl(urlTomorow);
       await this.setCameraImage('tomorrowPriceChart', ` ${this.homey.__('tomorrow')}`, this.tomorrowPriceImage);
-    } else {
-      await this.tomorrowPriceImage.setUrl(urlTomorow);
-      await this.tomorrowPriceImage.update();
     }
+    this.tomorrowPriceImage.setStream(async (stream) => {
+      return imageUrlToStream(urlTomorow, stream);
+    });
+    await this.tomorrowPriceImage.update();
 
     const startHour = this.priceInterval === 60 ? this.state.H0 : this.state.Q0 * (this.priceInterval / 60);
     const urlNextHours = await charts.getPriceChart(this.state.pricesNextHours, startHour, this.state.pricesNextHoursMarketLength, this.priceInterval);
     if (!this.nextHoursPriceImage) {
       this.nextHoursPriceImage = await this.homey.images.createImage();
-      await this.nextHoursPriceImage.setUrl(urlNextHours);
       await this.setCameraImage('nextHoursPriceChart', ` ${this.homey.__('nextHours')}`, this.nextHoursPriceImage);
-    } else {
-      await this.nextHoursPriceImage.setUrl(urlNextHours);
-      await this.nextHoursPriceImage.update();
     }
+    this.nextHoursPriceImage.setStream(async (stream) => {
+      return imageUrlToStream(urlNextHours, stream);
+    });
+    await this.nextHoursPriceImage.update();
   }
 
   async setCapabilitiesAndFlows(options) {

--- a/image.js
+++ b/image.js
@@ -1,0 +1,30 @@
+const { Readable } = require('stream');
+const fetch = require('node-fetch');
+
+const imageCache = [];
+
+const imageUrlToStream = async (url, stream) => {
+    // check if url is in cache
+    let cacheObject = imageCache.find(object => object.url === url);
+    if (cacheObject) {
+        const readable = Readable.from(cacheObject.buffer);
+        return readable.pipe(stream);
+    }
+
+    const res = await fetch(url);
+    if (!res.ok) {
+        throw new Error("Invalid Response");
+    }
+    const body = await res.arrayBuffer();
+    cacheObject = { url, buffer: Buffer.from(body) };
+    imageCache.push(cacheObject);
+    if (imageCache.length > 5) {
+        imageCache.shift();
+    }
+    const readable = Readable.from(cacheObject.buffer);
+    return readable.pipe(stream);
+};
+
+module.exports = {
+    imageUrlToStream,
+};


### PR DESCRIPTION
When loading images I noticed there was a really small limit on image-charts.com requests (10 per ip per minute). And unfortunately the request where done per client device and when viewing one graph the app/web does at least 2 requests (not sure why).

Using this cache it will just do the request and reuse the result for a while.