### PR TITLE
Add flow action to set daily fixed cost (markup_day)

### DIFF
--- a/.homeycompose/flow/actions/set_daily_fixed_cost.json
+++ b/.homeycompose/flow/actions/set_daily_fixed_cost.json
@@ -1,0 +1,45 @@
+{
+  "title": {
+    "en": "Set daily fixed cost",
+    "de": "Tägliche Fixkosten festlegen",
+    "sv": "Ställ in daglig fast kostnad",
+    "it": "Imposta costo fisso giornaliero",
+    "no": "Sett daglig fast kostnad",
+    "fr": "Définir le coût fixe journalier",
+    "dk": "Sæt daglig fast omkostning",
+    "nl": "Stel dagelijkse vaste kosten in"
+  },
+  "titleFormatted": {
+    "en": "Set daily fixed cost to [[value]]",
+    "de": "Tägliche Fixkosten auf [[value]] setzen",
+    "sv": "Ställ in daglig fast kostnad till [[value]]",
+    "it": "Imposta costo fisso giornaliero a [[value]]",
+    "no": "Sett daglig fast kostnad til [[value]]",
+    "fr": "Définir le coût fixe journalier à [[value]]",
+    "dk": "Sæt daglig fast omkostning til [[value]]",
+    "nl": "Stel dagelijkse vaste kosten in op [[value]]"
+  },
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "driver_id=power|gas|water"
+    },
+    {
+      "type": "number",
+      "name": "value",
+      "placeholder": {
+        "en": "Daily fixed cost",
+        "de": "Tägliche Fixkosten",
+        "sv": "Daglig fast kostnad",
+        "it": "Costo fisso giornaliero",
+        "no": "Daglig fast kostnad",
+        "fr": "Coût fixe journalier",
+        "dk": "Daglig fast omkostning",
+        "nl": "Dagelijkse vaste kosten"
+      },
+      "min": 0,
+      "decimals": 4
+    }
+  ]
+}

--- a/app.js
+++ b/app.js
@@ -364,6 +364,10 @@ class MyApp extends Homey.App {
     setFixedMarkupWeekend
       .registerRunListener((args) => args.device.setFixedMarkupWeekend(args.value));
 
+    const setDailyFixedCost = this.homey.flow.getActionCard('set_daily_fixed_cost');
+    setDailyFixedCost
+      .registerRunListener((args) => args.device.setDailyFixedCost(args.value).catch(this.error));
+
     const setExchangeRate = this.homey.flow.getActionCard('set_exchange_rate');
     setExchangeRate
       .registerRunListener((args) => args.device.setExchangeRate(args.value).catch(this.error));

--- a/app.json
+++ b/app.json
@@ -3268,6 +3268,52 @@
       },
       {
         "title": {
+          "en": "Set daily fixed cost",
+          "de": "Tägliche Fixkosten festlegen",
+          "sv": "Ställ in daglig fast kostnad",
+          "it": "Imposta costo fisso giornaliero",
+          "no": "Sett daglig fast kostnad",
+          "fr": "Définir le coût fixe journalier",
+          "dk": "Sæt daglig fast omkostning",
+          "nl": "Stel dagelijkse vaste kosten in"
+        },
+        "titleFormatted": {
+          "en": "Set daily fixed cost to [[value]]",
+          "de": "Tägliche Fixkosten auf [[value]] setzen",
+          "sv": "Ställ in daglig fast kostnad till [[value]]",
+          "it": "Imposta costo fisso giornaliero a [[value]]",
+          "no": "Sett daglig fast kostnad til [[value]]",
+          "fr": "Définir le coût fixe journalier à [[value]]",
+          "dk": "Sæt daglig fast omkostning til [[value]]",
+          "nl": "Stel dagelijkse vaste kosten in op [[value]]"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=power|gas|water"
+          },
+          {
+            "type": "number",
+            "name": "value",
+            "placeholder": {
+              "en": "Daily fixed cost",
+              "de": "Tägliche Fixkosten",
+              "sv": "Daglig fast kostnad",
+              "it": "Costo fisso giornaliero",
+              "no": "Daglig fast kostnad",
+              "fr": "Coût fixe journalier",
+              "dk": "Daglig fast omkostning",
+              "nl": "Dagelijkse vaste kosten"
+            },
+            "min": 0,
+            "decimals": 4
+          }
+        ],
+        "id": "set_daily_fixed_cost"
+      },
+      {
+        "title": {
           "en": "Set a new exchange rate",
           "de": "Neuen Wechselkurs festlegen",
           "sv": "Ställ in en ny växelkurs",

--- a/drivers/generic_sum_device.js
+++ b/drivers/generic_sum_device.js
@@ -602,6 +602,12 @@ class SumMeterDevice extends Device {
     }
   }
 
+  async setDailyFixedCost(cost) {
+    const v = Number(cost);
+    await this.setSettings({ markup_day: Number.isFinite(v) ? v : 0 });
+    return true;
+  }
+  
   async handleUpdateMeter(reading) {
     try {
       const periods = this.getPeriods(reading); // check for new hour/day/month/year


### PR DESCRIPTION
Related to #311
This PR adds a new Flow action to update the daily fixed cost (markup_day).

This allows users to automatically adjust daily fixed costs (e.g. monthly
subscription divided by the number of days in the month), without changing
any existing calculation logic.
- Uses existing markup_day setting
- No behavioral change unless the new action is used
- Fully aligned with existing flow action patterns

Note: this action currently applies to power summarizers; gas and water devices can be extended similarly if needed.